### PR TITLE
fix: set default description

### DIFF
--- a/CrashDialogForm.cs
+++ b/CrashDialogForm.cs
@@ -33,6 +33,7 @@ namespace BugSplatCrashHandler
             // Update dialog text
             usernameTextBox.Text = options.User;
             emailTextBox.Text = options.Email;
+            userDescriptionTextBox.Text = options.Description;
         }
 
         private void userDescriptionTextBox_TextChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Description

We forgot to set the default description that the developer sets in via BugSplatNative...

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
